### PR TITLE
Hotfix/no subs timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wizdom-stremio-express",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wizdom-stremio-express",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "GPL-3.0",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizdom-stremio-express",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Stremio addon for Hebrew subtitles from wizdom.xyz using express this time",
   "main": "index.js",
   "scripts": {

--- a/wizdom.js
+++ b/wizdom.js
@@ -29,7 +29,7 @@ const getSubs = async (imdbID, filename) => {
     ).body;
 
     subsArr = titleInfo.subs;
-    if (season || episode) subsArr = subsArr[season][episode];
+    if (season || episode) subsArr = subsArr[season][episode] ?? [];
 
     if (filename) {
       subsArr.sort((firstSub, secondSub) => {


### PR DESCRIPTION
This went unnoticed but when an episode was missing subs you'd get a timeout instead of an empty subs array.
This Fix won't affect the user because a timeout for him equals not getting any subs which is the correct response.
This will produce better logs so I decided to fix it anyway.