### PR TITLE
Fix: Install link in landing template

### DIFF
--- a/middlewares/landingTemplate.js
+++ b/middlewares/landingTemplate.js
@@ -283,7 +283,7 @@ function landingTemplate(manifest) {
          </div>
       </div>
       <script>
-         installLink.href = 'stremio://' + window.location.host + '/manifest.mock.js'
+         installLink.href = 'stremio://' + window.location.host + '/manifest.json'
       </script>
       
 	</body>


### PR DESCRIPTION
One of my refactoring broke the install link in the landing page due to a "Find and replace all" change.

Restored back to normal